### PR TITLE
Bugfix/double cart issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 ## Changes in release 4.1.0 ##
 + PS1.7 - Credit card components are now indexed with tabbable feature meaning that clicking TAB in keyboard will point to next credit card input option.
 + Fixed Order creation in BO crashed page error.
++ After successful payment process memorized cart is now being removed by default. This behavior is added to ensure merchants wont have duplicated carts then
+  they are not required.
 
 
 ## Changes in release 4.0.9 Hotfix-1 ##

--- a/config/service.yml
+++ b/config/service.yml
@@ -107,6 +107,7 @@ services:
   Mollie\Service\MemorizeCartService:
     arguments:
       - '@Mollie\Service\OrderCartAssociationService'
+      - '@Mollie\Repository\PendingOrderCartRepository'
 
   Mollie\Service\RepeatOrderLinkFactory:
 

--- a/controllers/front/return.php
+++ b/controllers/front/return.php
@@ -33,6 +33,7 @@
  * @codingStandardsIgnoreStart
  */
 
+use Mollie\Service\MemorizeCartService;
 use MolliePrefix\Mollie\Api\Types\PaymentMethod;
 use MolliePrefix\Mollie\Api\Types\PaymentStatus;
 use Mollie\Controller\AbstractMollieController;
@@ -307,6 +308,11 @@ class MollieReturnModuleFrontController extends AbstractMollieController
                     $paymentMethod,
                     $stockManagement
                 );
+
+                /** @var MemorizeCartService $memorizeCart */
+                $memorizeCart = $this->module->getContainer(MemorizeCartService::class);
+                $memorizeCart->removeMemorizedCart($order);
+
                 break;
             case PaymentStatus::STATUS_EXPIRED:
             case PaymentStatus::STATUS_CANCELED:

--- a/mollie.php
+++ b/mollie.php
@@ -738,7 +738,7 @@ class Mollie extends PaymentModule
         $issuerList = [];
         foreach ($methods as $method) {
             $methodObj = new MolPaymentMethod($method['id_payment_method']);
-            if ($methodObj->id_method === Mollie\Api\Types\PaymentMethod::IDEAL) {
+            if ($methodObj->id_method === \MolliePrefix\Mollie\Api\Types\PaymentMethod::IDEAL) {
                 $issuerList = $issuerService->getIdealIssuers();
             }
         }
@@ -747,8 +747,8 @@ class Mollie extends PaymentModule
         $cart = $context->cart;
 
         $context->smarty->assign([
-            'idealIssuers' => isset($issuerList[Mollie\Api\Types\PaymentMethod::IDEAL])
-                ? $issuerList[Mollie\Api\Types\PaymentMethod::IDEAL]
+            'idealIssuers' => isset($issuerList[\MolliePrefix\Mollie\Api\Types\PaymentMethod::IDEAL])
+                ? $issuerList[\MolliePrefix\Mollie\Api\Types\PaymentMethod::IDEAL]
                 : [],
             'link' => $this->context->link,
             'qrCodeEnabled' => Configuration::get(Mollie\Config\Config::MOLLIE_QRENABLED),
@@ -775,9 +775,9 @@ class Mollie extends PaymentModule
             }
             $paymentFee = \Mollie\Utility\PaymentFeeUtility::getPaymentFee($methodObj, $cart->getOrderTotal());
 
-            $isIdealMethod = $methodObj->id_method === Mollie\Api\Types\PaymentMethod::IDEAL;
+            $isIdealMethod = $methodObj->id_method === \MolliePrefix\Mollie\Api\Types\PaymentMethod::IDEAL;
             $isIssuersOnClick = Configuration::get(Mollie\Config\Config::MOLLIE_ISSUERS) === Mollie\Config\Config::ISSUERS_ON_CLICK;
-            $isCreditCardMethod = $methodObj->id_method === Mollie\Api\Types\PaymentMethod::CREDITCARD;
+            $isCreditCardMethod = $methodObj->id_method === \MolliePrefix\Mollie\Api\Types\PaymentMethod::CREDITCARD;
 
             if ($isIdealMethod && $isIssuersOnClick) {
                 $newOption = new PrestaShop\PrestaShop\Core\Payment\PaymentOption();
@@ -939,7 +939,7 @@ class Mollie extends PaymentModule
         /** @var \Mollie\Repository\PaymentMethodRepository $paymentMethodRepo */
         $paymentMethodRepo = $this->getContainer(\Mollie\Repository\PaymentMethodRepository::class);
         $payment = $paymentMethodRepo->getPaymentBy('cart_id', (int)Tools::getValue('id_cart'));
-        if ($payment && $payment['bank_status'] == Mollie\Api\Types\PaymentStatus::STATUS_PAID) {
+        if ($payment && $payment['bank_status'] == \MolliePrefix\Mollie\Api\Types\PaymentStatus::STATUS_PAID) {
             $this->context->smarty->assign('okMessage', $this->l('Thank you. Your payment has been received.'));
 
             return $this->display(__FILE__, 'ok.tpl');

--- a/src/Service/MemorizeCartService.php
+++ b/src/Service/MemorizeCartService.php
@@ -35,6 +35,9 @@
 
 namespace Mollie\Service;
 
+use Cart;
+use Mollie\Repository\ReadOnlyRepositoryInterface;
+use MolPendingOrderCart;
 use Order;
 
 /**
@@ -43,15 +46,39 @@ use Order;
 class MemorizeCartService
 {
     private $orderCartAssociationService;
+    private $pendingOrderCartRepository;
 
-    public function __construct(OrderCartAssociationService $orderCartAssociationService)
-    {
+    public function __construct(
+        OrderCartAssociationService $orderCartAssociationService,
+        ReadOnlyRepositoryInterface $pendingOrderCartRepository
+    ) {
         $this->orderCartAssociationService = $orderCartAssociationService;
+        $this->pendingOrderCartRepository = $pendingOrderCartRepository;
     }
 
     public function memorizeCart(Order $toBeProcessedOrder)
     {
         // create a pending cart so we can repeat the process once again
         $this->orderCartAssociationService->createPendingCart($toBeProcessedOrder);
+    }
+
+    public function removeMemorizedCart(Order $successfulProcessedOrder)
+    {
+        /** @var MolPendingOrderCart|null $pendingOrderCart */
+        $pendingOrderCart = $this->pendingOrderCartRepository->findOneBy([
+            'order_id' => $successfulProcessedOrder->id
+        ]);
+
+        if (null === $pendingOrderCart) {
+            return;
+        }
+
+        $cart = new Cart($pendingOrderCart->cart_id);
+
+        if (!\Validate::isLoadedObject($cart)) {
+            return;
+        }
+
+        $cart->delete();
     }
 }


### PR DESCRIPTION
After successful payment process memorized cart is now being removed by default. This behavior is added to ensure merchants wont have duplicated carts then they are not required.