### PR TITLE
4.0.10 upgrade with awaiting mollie order state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
 + Fixed Order creation in BO crashed page error.
 + After successful payment process memorized cart is now being removed by default. This behavior is added to ensure merchants wont have duplicated carts then
   they are not required.
-
++ Fixed Order state "Awaiting Mollie payment" giving error on order creation when upgraded from mollie v3.4.5
 
 ## Changes in release 4.0.9 Hotfix-1 ##
 + In PS1.6 prevents double click payment method to create multiple orders

--- a/src/Install/Installer.php
+++ b/src/Install/Installer.php
@@ -226,7 +226,7 @@ class Installer
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
-    private function awaitingMollieOrderState()
+    public function awaitingMollieOrderState()
     {
         $orderState = new OrderState();
         $orderState->send_email = false;

--- a/upgrade/Upgrade-4.0.10.php
+++ b/upgrade/Upgrade-4.0.10.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright (c) 2012-2020, Mollie B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * @author     Mollie B.V. <info@mollie.nl>
+ * @copyright  Mollie B.V.
+ * @license    Berkeley Software Distribution License (BSD-License 2) http://www.opensource.org/licenses/bsd-license.php
+ * @category   Mollie
+ * @package    Mollie
+ * @link       https://www.mollie.nl
+ */
+
+use Mollie\Install\Installer;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * @param Mollie $module
+ * @return bool
+ */
+
+function upgrade_module_4_0_10($module)
+{
+    $upgraded = true;
+
+    /** @var Installer $installer */
+    $installer = $module->getContainer(Installer::class);
+
+    $stateExists = false;
+    $languageId = Context::getContext()->language->id;
+    $states = OrderState::getOrderStates((int)$languageId);
+    foreach ($states as $state) {
+        if ($module->l('Awaiting Mollie payment') === $state['name']) {
+            $stateExists = true;
+            break;
+        }
+    }
+
+    if (!Configuration::get(\Mollie\Config\Config::MOLLIE_AWAITING_PAYMENT) || !$stateExists) {
+        $upgraded &= $installer->awaitingMollieOrderState();
+    }
+
+    return $upgraded;
+}


### PR DESCRIPTION
Checking if state exists or is empty configuration value to not create new awaiting mollie order state.