### PR TITLE
MOL-327 added rubles because docs says that it is supported.

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -53,7 +53,7 @@ class Config
         'belfius' => ['eur'],
         'bitcoin' => ['eur'],
         'cartesbancaires' => ['eur'],
-        'creditcard' => ['aud', 'bgn', 'cad', 'chf', 'czk', 'dkk', 'eur', 'gbp', 'hkd', 'hrk', 'huf', 'ils', 'isk', 'jpy', 'pln', 'ron', 'sek', 'usd'],
+        'creditcard' => ['aud', 'bgn', 'cad', 'chf', 'czk', 'dkk', 'eur', 'gbp', 'hkd', 'hrk', 'huf', 'ils', 'isk', 'jpy', 'pln', 'ron', 'sek', 'usd', 'rub'],
         'directdebit' => ['eur'],
         'eps' => ['eur'],
         'giftcard' => ['eur'],


### PR DESCRIPTION
In mollie docs https://docs.mollie.com/payments/multicurrency it is specified that Rubles is supported by Paypal and Credit Card.