### PR TITLE
4.1.x left menu icon fix

### DIFF
--- a/upgrade/Upgrade-4.0.7.php
+++ b/upgrade/Upgrade-4.0.7.php
@@ -79,7 +79,7 @@ function upgrade_module_4_0_7($module)
     $installed = true;
 
     $installed &= $installer->installTab('AdminMollieAjax', 0, 'AdminMollieAjax', false);
-    $installed &= $installer->installTab('AdminMollieModule', 0, 'Mollie', false, 'mollie');
+    $installed &= $installer->installTab('AdminMollieModule', 'IMPROVE', 'Mollie', false, 'mollie');
 
     $installed &= $installer->createPartialShippedOrderState();
     $installed &= $installer->createOrderCompletedOrderState();


### PR DESCRIPTION
MOL-112 Fixed issue where left menu icon was not visible after module reset 